### PR TITLE
Bubble fgt parameters up to registration

### DIFF
--- a/include/cpd/registration.hpp
+++ b/include/cpd/registration.hpp
@@ -42,13 +42,21 @@ public:
     constexpr static const double DEFAULT_TOLERANCE = 1e-5;
     /// Default outlier weight.
     constexpr static const double DEFAULT_OUTLIER_WEIGHT = 0.1;
+    /// Default error tolerance for the Fast Gauss Transform.
+    constexpr static const double DEFAULT_FGT_EPSILON = 1e-4;
+    /// Default Fast Gauss Transform bandwidth breakpoint.
+    ///
+    /// Above this point, we use IFGT — below, we use direct+tree.
+    constexpr static const double DEFAULT_FGT_BREAKPOINT = 0.2;
 
     /// Creates a new registration with default values.
     Registration()
         : m_max_iterations(DEFAULT_MAX_ITERATIONS),
           m_tolerance(DEFAULT_TOLERANCE),
           m_outlier_weight(DEFAULT_OUTLIER_WEIGHT),
-          m_ostream(std::cout) {}
+          m_ostream(std::cout),
+          m_fgt_epsilon(DEFAULT_FGT_EPSILON),
+          m_fgt_breakpoint(DEFAULT_FGT_BREAKPOINT) {}
 
     /// Returns an ostream that can be used to print messages.
     ///
@@ -74,6 +82,22 @@ public:
     /// Sets the outlier weight.
     Registration& set_outlier_weight(double outlier_weight) {
         m_outlier_weight = outlier_weight;
+        return *this;
+    }
+
+    /// Returns the fgt error tolerance.
+    double fgt_epsilon() const { return m_fgt_epsilon; }
+    /// Sets the fgt error tolerance.
+    Registration& set_fgt_epsilon(double fgt_epsilon) {
+        m_fgt_epsilon = fgt_epsilon;
+        return *this;
+    }
+
+    /// Returns the fgt breakpoint.
+    double fgt_breakpoint() const { return m_fgt_breakpoint; }
+    /// Sets the fgt breakpoint.
+    Registration& set_fgt_breakpoint(double fgt_breakpoint) {
+        m_fgt_breakpoint = fgt_breakpoint;
         return *this;
     }
 
@@ -104,5 +128,7 @@ private:
     double m_tolerance;
     double m_outlier_weight;
     std::ostream& m_ostream;
+    double m_fgt_epsilon;
+    double m_fgt_breakpoint;
 };
 }

--- a/src/affine.cpp
+++ b/src/affine.cpp
@@ -45,8 +45,8 @@ RigidResult Affine::compute_impl(const MatrixRef X, const MatrixRef Y,
            sigma2 > 10 * std::numeric_limits<double>::epsilon()) {
         double L_old = L;
 
-        std::tie(Pt1, P1, PX, L) =
-            calculate_probabilities(X, T, sigma2, outliers);
+        std::tie(Pt1, P1, PX, L) = calculate_probabilities(
+            X, T, sigma2, outliers, fgt_epsilon(), fgt_breakpoint());
         ntol = std::abs((L - L_old) / L);
 
         log() << "CPD Affine (FGT) : dL= " << ntol << ", iter= " << iter

--- a/src/nonrigid.cpp
+++ b/src/nonrigid.cpp
@@ -53,8 +53,8 @@ NonrigidResult Nonrigid::compute_impl(const MatrixRef X, const MatrixRef Y,
     while (iter < max_iter && ntol > tol &&
            sigma2 > 10 * std::numeric_limits<double>::epsilon()) {
         double L_old = L;
-        std::tie(Pt1, P1, PX, L) =
-            calculate_probabilities(X, T, sigma2, outliers);
+        std::tie(Pt1, P1, PX, L) = calculate_probabilities(
+            X, T, sigma2, outliers, fgt_epsilon(), fgt_breakpoint());
         L = L + lambda / 2 * (W.transpose() * G * W).trace();
         ntol = std::abs((L - L_old) / L);
 

--- a/src/rigid.cpp
+++ b/src/rigid.cpp
@@ -64,8 +64,8 @@ RigidResult Rigid::compute_impl(const MatrixRef X, const MatrixRef Y,
         // TODO myronenko has a sigma2 floor, which we may need for real
         // datasets
 
-        std::tie(Pt1, P1, PX, L) =
-            calculate_probabilities(X, T, sigma2, outliers);
+        std::tie(Pt1, P1, PX, L) = calculate_probabilities(
+            X, T, sigma2, outliers, fgt_epsilon(), fgt_breakpoint());
         ntol = std::abs((L - L_old) / L);
 
         log() << "CPD Rigid (FGT) : dL= " << ntol << ", iter= " << iter

--- a/src/transformer.cpp
+++ b/src/transformer.cpp
@@ -19,10 +19,6 @@
 
 namespace cpd {
 
-Transformer::Transformer()
-    : m_epsilon(Transformer::DEFAULT_EPSILON),
-      m_breakpoint(Transformer::DEFAULT_BREAKPOINT) {}
-
 Transformer::Transformer(double epsilon, double breakpoint)
     : m_epsilon(epsilon), m_breakpoint(breakpoint) {}
 

--- a/src/transformer.hpp
+++ b/src/transformer.hpp
@@ -30,13 +30,6 @@ namespace cpd {
 /// This class also lets us store pre-computed clusterings for multiple runs.
 class Transformer {
 public:
-    /// Default error tolerance for fgts.
-    const double DEFAULT_EPSILON = 1e-4;
-    /// Default breakpoint.
-    const double DEFAULT_BREAKPOINT = 0.2;
-
-    /// Creates a new transformer with default parameters.
-    Transformer();
     /// Creates a new transformer with specified parameters.
     Transformer(double epsilon, double breakpoint);
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -39,12 +39,12 @@ Matrix construct_affinity_matrix(const MatrixRef X, const MatrixRef Y,
 
 std::tuple<Vector, Vector, Matrix, double>
 calculate_probabilities(const MatrixRef X, const MatrixRef Y, double sigma2,
-                        double outliers) {
+                        double outliers, double fgt_epsilon, double fgt_breakpoint) {
     assert(X.cols() == Y.cols());
     unsigned long N = X.rows();
     unsigned long M = Y.rows();
     unsigned long D = X.cols();
-    Transformer transformer;
+    Transformer transformer(fgt_epsilon, fgt_breakpoint);
     double hsigma = std::sqrt(2.0 * sigma2);
     Vector Kt1 = transformer.fgt(Y, X, hsigma);
     double ndi = outliers / (1 - outliers) * M / N *

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -26,5 +26,6 @@ Matrix construct_affinity_matrix(const MatrixRef source, const MatrixRef target,
 
 std::tuple<Vector, Vector, Matrix, double>
 calculate_probabilities(const MatrixRef source, const MatrixRef target,
-                        double sigma2, double outliers);
+                        double sigma2, double outliers, double fgt_epsilon,
+                        double fgt_breakpoint);
 }


### PR DESCRIPTION
This enables getting and setting these parameters on a registration, where before they were hidden and uneditable.

This gives the user the power to force ifgt or direct-tree, by setting `fgt_breakpoint` high (for direct-tree) or low (for ifgt). Enough to fix #61.