### PR TITLE
Add translation vectors to rigid result

### DIFF
--- a/include/cpd/rigid.hpp
+++ b/include/cpd/rigid.hpp
@@ -78,4 +78,7 @@ RigidResult rigid(const MatrixRef source, const MatrixRef target);
 /// Runs rigid CPD with the provided sigma2.
 RigidResult rigid(const MatrixRef source, const MatrixRef target,
                   double sigma2);
+
+template <>
+RigidResult Normalization::denormalize(const RigidResult& result) const;
 }

--- a/include/cpd/rigid.hpp
+++ b/include/cpd/rigid.hpp
@@ -31,6 +31,10 @@ struct RigidResult {
     Matrix points;
     /// The calculated rotation matrix.
     Matrix rotation;
+    /// The calculated translation vector.
+    Vector translation;
+    /// The calculated scale factor.
+    double scaling;
 };
 
 /// Class-based interface for running a rigid registration.

--- a/src/affine.cpp
+++ b/src/affine.cpp
@@ -73,7 +73,7 @@ RigidResult Affine::compute_impl(const MatrixRef X, const MatrixRef Y,
             (Np * D);
         ++iter;
     }
-    return {T, B};
+    return {T, B, t, 1.0};
 }
 
 RigidResult affine(const MatrixRef source, const MatrixRef target) {

--- a/src/rigid.cpp
+++ b/src/rigid.cpp
@@ -105,6 +105,17 @@ RigidResult Rigid::compute_impl(const MatrixRef X, const MatrixRef Y,
         T = s * Y * R.transpose() + t.transpose().replicate(M, 1);
         ++iter;
     }
-    return {T, R};
+    return {T, R, t, s};
+}
+
+template <>
+RigidResult Normalization::denormalize(const RigidResult& result) const {
+    RigidResult out(result);
+    out.points = result.points * m_scaling +
+                 m_translation.replicate(result.points.rows(), 1);
+    out.translation =
+        m_scaling * result.translation + m_translation.transpose() -
+        result.scaling * result.rotation * m_translation.transpose();
+    return out;
 }
 }

--- a/test/affine_test.cpp
+++ b/test/affine_test.cpp
@@ -1,5 +1,5 @@
-#include "test/support.hpp"
 #include "cpd/affine.hpp"
+#include "test/support.hpp"
 
 namespace cpd {
 
@@ -10,5 +10,9 @@ TEST_F(AffineTest, StandaloneFunction) {
     ASSERT_EQ(m_fish2.rows(), result.points.rows());
     EXPECT_TRUE(m_fish1.isApprox(result.points, 1e-4));
     EXPECT_TRUE(m_rotation.matrix().isApprox(result.rotation, 1e-4));
+    EXPECT_TRUE(
+        m_translation.transpose().isApprox(-1 * result.translation, 1e-4))
+        << result.translation;
+    EXPECT_DOUBLE_EQ(1.0, result.scaling);
 }
 }

--- a/test/rigid_test.cpp
+++ b/test/rigid_test.cpp
@@ -10,6 +10,10 @@ TEST_F(RigidTest, StandaloneFunction) {
     ASSERT_EQ(m_fish2.rows(), result.points.rows());
     EXPECT_TRUE(m_fish1.isApprox(result.points, 1e-4));
     EXPECT_TRUE(m_rotation.matrix().isApprox(result.rotation, 1e-4));
+    EXPECT_TRUE(
+        m_translation.transpose().isApprox(-1 * result.translation, 1e-4))
+        << result.translation;
+    EXPECT_DOUBLE_EQ(1.0, result.scaling);
 }
 
 TEST_F(RigidTest, ClassBased) {


### PR DESCRIPTION
Both affine and rigid registrations produce a translation vector, but we
were not providing those vectors as a part of the output. This patch
amends that error.

Fixes #65.