### PR TITLE
Make libfgt an optional dependency

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,8 @@ install:
   - ps: cd ..\..\cpd
 
 before_build:
-  - cmd: cmake -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=C:\projects\local -Dgtest_force_shared_crt=ON -DBUILD_SHARED_LIBS=OFF .
+  # TODO use build matrix to test with and w/o libfgt
+  - cmd: cmake -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=C:\projects\local -Dgtest_force_shared_crt=ON -DBUILD_SHARED_LIBS=OFF -DWITH_FGT=ON .
 
 build:
   parallel: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: cpp
 env:
   global:
     secure: CQVCboz7xZV5gxHlJ9PBBR8BUT8HA0AWaq3My+dixHvb/4qxw9Qux/brxNObEv4nzu2CUFLpVjsj9kLRzmcvPOMmbLR2NdJFIDkl0g4BgZJcq4+YTlNyMj76x4DWpFupDDtrJKL/RUNCMURXTgHQnZMjJmhx4mrL4RbY4ZcR6VI=
+  matrix:
+    - CPD_WITH_FGT=ON
+    - CPD_WITH_FGT=OFF
 
 compiler:
   - clang
@@ -23,7 +26,7 @@ before_install:
 install:
   - scripts/travis-install-cmake.sh && export PATH=$(pwd)/cmake/bin:$PATH
   - scripts/travis-install-eigen3.sh
-  - scripts/travis-install-fgt.sh
+  - if [ "$CPD_WITH_FGT" = "ON" ]; then scripts/travis-install-fgt.sh; fi
 
 script: scripts/travis-script.sh
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 set(CPD_LANGUAGES CXX C)
 set(CPD_VERSION 0.4.2)
 set(CPD_SOVERSION 0)
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # Policies
 if(POLICY CMP0048) # Project version
@@ -20,7 +21,12 @@ if(POLICY CMP0054) # Quoted variables in if statements
 endif()
 
 # Depdencies
-find_package(Fgt REQUIRED)
+option(WITH_FGT "Build with libfgt" OFF)
+if(WITH_FGT)
+    find_package(Fgt REQUIRED)
+else()
+    find_package(Eigen3 REQUIRED)
+endif()
 
 # Configuration
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
@@ -34,35 +40,61 @@ write_basic_package_version_file("${PROJECT_BINARY_DIR}/cmake/cpd-config-version
 install(FILES cmake/cpd-config.cmake "${PROJECT_BINARY_DIR}/cmake/cpd-config-version.cmake" DESTINATION lib/cmake/cpd)
 configure_file(src/version.cpp.in "${PROJECT_BINARY_DIR}/src/version.cpp")
 
-option(WITH_STRICT_WARNINGS "Build with stricter warnings" ON)
-if(WITH_STRICT_WARNINGS)
-    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wno-gnu-zero-variadic-macro-arguments")
-    endif()
-endif()
-
 # Targets
+set(library_headers
+    include/cpd/comparer/direct.hpp
+    include/cpd/logging.hpp
+    include/cpd/matrix.hpp
+    include/cpd/nonrigid.hpp
+    include/cpd/normalize.hpp
+    include/cpd/probabilities.hpp
+    include/cpd/rigid.hpp
+    include/cpd/runner.hpp
+    include/cpd/utils.hpp
+    include/cpd/version.hpp
+    )
 set(library_src
     src/affinity_matrix.cpp
-    src/comparer.cpp
+    src/comparer/direct.cpp
     src/nonrigid.cpp
     src/normalize.cpp
     src/rigid.cpp
     src/utils.cpp
     "${PROJECT_BINARY_DIR}/src/version.cpp"
     )
+if(WITH_FGT)
+    list(APPEND library_headers include/cpd/comparer/fgt.hpp)
+    list(APPEND library_src src/comparer/fgt.cpp)
+endif()
+
 add_library(Library-C++ ${library_src})
 set_target_properties(Library-C++ PROPERTIES
     OUTPUT_NAME cpd
     VERSION ${CPD_VERSION}
     SOVERSION ${CPD_SOVERSION}
     )
-target_link_libraries(Library-C++ PUBLIC Fgt::Library-C++)
 target_include_directories(Library-C++
     INTERFACE $<INSTALL_INTERFACE:include> $<INSTALL_INTERFACE:include/cpd/vendor>
     PRIVATE include include/cpd/vendor)
+if(WITH_FGT)
+    target_link_libraries(Library-C++ PUBLIC Fgt::Library-C++)
+    target_compile_definitions(Library-C++ PUBLIC CPD_WITH_FGT)
+else()
+    target_include_directories(Library-C++ PUBLIC ${EIGEN3_INCLUDE_DIR})
+    target_compile_options(Library-C++ PUBLIC -std=c++11)
+endif()
+
+option(WITH_STRICT_WARNINGS "Build with stricter warnings" ON)
+if(WITH_STRICT_WARNINGS)
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+        target_compile_options(Library-C++ PRIVATE -Wall -pedantic -Wno-gnu-zero-variadic-macro-arguments)
+    endif()
+endif()
+
+
 install(TARGETS Library-C++ DESTINATION lib EXPORT cpd-targets)
-install(DIRECTORY include/cpd DESTINATION include)
+install(FILES ${library_headers} DESTINATION include/cpd)
+install(DIRECTORY include/cpd/vendor DESTINATION include/cpd)
 install(EXPORT cpd-targets NAMESPACE Cpd:: DESTINATION lib/cmake/cpd)
 
 # Optional targets
@@ -73,7 +105,7 @@ if(WITH_TESTS)
     add_subdirectory(test)
 endif()
 
-option(WITH_DOCS "Build documentation" OFF)
+option(WITH_DOCS "Add documentation target" OFF)
 if(WITH_DOCS)
     configure_file(Doxyfile.in "${PROJECT_BINARY_DIR}/Doxyfile")
     add_custom_target(docs COMMAND doxygen "${PROJECT_BINARY_DIR}/Doxyfile")

--- a/cmake/FindEigen3.cmake
+++ b/cmake/FindEigen3.cmake
@@ -1,0 +1,81 @@
+# - Try to find Eigen3 lib
+#
+# This module supports requiring a minimum version, e.g. you can do
+#   find_package(Eigen3 3.1.2)
+# to require version 3.1.2 or newer of Eigen3.
+#
+# Once done this will define
+#
+#  EIGEN3_FOUND - system has eigen lib with correct version
+#  EIGEN3_INCLUDE_DIR - the eigen include directory
+#  EIGEN3_VERSION - eigen version
+
+# Copyright (c) 2006, 2007 Montel Laurent, <montel@kde.org>
+# Copyright (c) 2008, 2009 Gael Guennebaud, <g.gael@free.fr>
+# Copyright (c) 2009 Benoit Jacob <jacob.benoit.1@gmail.com>
+# Redistribution and use is allowed according to the terms of the 2-clause BSD license.
+
+if(NOT Eigen3_FIND_VERSION)
+  if(NOT Eigen3_FIND_VERSION_MAJOR)
+    set(Eigen3_FIND_VERSION_MAJOR 2)
+  endif(NOT Eigen3_FIND_VERSION_MAJOR)
+  if(NOT Eigen3_FIND_VERSION_MINOR)
+    set(Eigen3_FIND_VERSION_MINOR 91)
+  endif(NOT Eigen3_FIND_VERSION_MINOR)
+  if(NOT Eigen3_FIND_VERSION_PATCH)
+    set(Eigen3_FIND_VERSION_PATCH 0)
+  endif(NOT Eigen3_FIND_VERSION_PATCH)
+
+  set(Eigen3_FIND_VERSION "${Eigen3_FIND_VERSION_MAJOR}.${Eigen3_FIND_VERSION_MINOR}.${Eigen3_FIND_VERSION_PATCH}")
+endif(NOT Eigen3_FIND_VERSION)
+
+macro(_eigen3_check_version)
+  file(READ "${EIGEN3_INCLUDE_DIR}/Eigen/src/Core/util/Macros.h" _eigen3_version_header)
+
+  string(REGEX MATCH "define[ \t]+EIGEN_WORLD_VERSION[ \t]+([0-9]+)" _eigen3_world_version_match "${_eigen3_version_header}")
+  set(EIGEN3_WORLD_VERSION "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "define[ \t]+EIGEN_MAJOR_VERSION[ \t]+([0-9]+)" _eigen3_major_version_match "${_eigen3_version_header}")
+  set(EIGEN3_MAJOR_VERSION "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "define[ \t]+EIGEN_MINOR_VERSION[ \t]+([0-9]+)" _eigen3_minor_version_match "${_eigen3_version_header}")
+  set(EIGEN3_MINOR_VERSION "${CMAKE_MATCH_1}")
+
+  set(EIGEN3_VERSION ${EIGEN3_WORLD_VERSION}.${EIGEN3_MAJOR_VERSION}.${EIGEN3_MINOR_VERSION})
+  if(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})
+    set(EIGEN3_VERSION_OK FALSE)
+  else(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})
+    set(EIGEN3_VERSION_OK TRUE)
+  endif(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})
+
+  if(NOT EIGEN3_VERSION_OK)
+
+    message(STATUS "Eigen3 version ${EIGEN3_VERSION} found in ${EIGEN3_INCLUDE_DIR}, "
+                   "but at least version ${Eigen3_FIND_VERSION} is required")
+  endif(NOT EIGEN3_VERSION_OK)
+endmacro(_eigen3_check_version)
+
+if (EIGEN3_INCLUDE_DIR)
+
+  # in cache already
+  _eigen3_check_version()
+  set(EIGEN3_FOUND ${EIGEN3_VERSION_OK})
+
+else (EIGEN3_INCLUDE_DIR)
+
+  find_path(EIGEN3_INCLUDE_DIR NAMES signature_of_eigen3_matrix_library
+      PATHS
+      ${CMAKE_INSTALL_PREFIX}/include
+      ${KDE4_INCLUDE_DIR}
+      PATH_SUFFIXES eigen3 eigen
+    )
+
+  if(EIGEN3_INCLUDE_DIR)
+    _eigen3_check_version()
+  endif(EIGEN3_INCLUDE_DIR)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Eigen3 DEFAULT_MSG EIGEN3_INCLUDE_DIR EIGEN3_VERSION_OK)
+
+  mark_as_advanced(EIGEN3_INCLUDE_DIR)
+
+endif(EIGEN3_INCLUDE_DIR)
+

--- a/include/cpd/comparer/default.hpp
+++ b/include/cpd/comparer/default.hpp
@@ -1,0 +1,32 @@
+// cpd - Coherent Point Drift
+// Copyright (C) 2016 Pete Gadomski <pete.gadomski@gmail.com>
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+/// \file
+/// Typedef the default comparer.
+///
+/// For now, this is hardcoded, but down the road this could be configured via
+/// CMake.
+
+#pragma once
+
+#include <cpd/comparer/direct.hpp>
+
+namespace cpd {
+
+/// The default comparer.
+typedef DirectComparer DefaultComparer;
+}

--- a/include/cpd/comparer/direct.hpp
+++ b/include/cpd/comparer/direct.hpp
@@ -1,0 +1,34 @@
+// cpd - Coherent Point Drift
+// Copyright (C) 2016 Pete Gadomski <pete.gadomski@gmail.com>
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+/// \file
+/// Compute correpondence proabilities using the direct method.
+
+#pragma once
+
+#include <cpd/matrix.hpp>
+#include <cpd/probabilities.hpp>
+
+namespace cpd {
+
+/// Use Myronenko's slow direct method to calculate probabilities.
+class DirectComparer {
+public:
+    Probabilities compute(const Matrix& fixed, const Matrix& moving,
+                          double sigma2, double outliers) const;
+};
+}

--- a/include/cpd/comparer/fgt.hpp
+++ b/include/cpd/comparer/fgt.hpp
@@ -16,14 +16,12 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 /// \file
-/// Compute correpondence proabilities between two datasets.
+/// Compute correpondence proabilities using libfgt.
 
 #pragma once
 
-#include <fgt.hpp>
-
-#include <cpd/matrix.hpp>
 #include <cpd/probabilities.hpp>
+#include <fgt.hpp>
 
 namespace cpd {
 
@@ -49,13 +47,6 @@ const double DEFAULT_EPSILON = 1e-4;
 const FgtMethod DEFAULT_METHOD = FgtMethod::DirectTree;
 /// Default ifgt->direct-tree breakpoint for fgt.
 const double DEFAULT_BREAKPOINT = 0.2;
-
-/// Use Myronenko's slow direct method to calculate probabilities.
-class DirectComparer {
-public:
-    Probabilities compute(const Matrix& fixed, const Matrix& moving,
-                          double sigma2, double outliers) const;
-};
 
 /// Use the fgt library to calculate probabilities.
 class FgtComparer {

--- a/include/cpd/runner.hpp
+++ b/include/cpd/runner.hpp
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <cpd/comparer.hpp>
+#include <cpd/comparer/default.hpp>
 #include <cpd/logging.hpp>
 #include <cpd/normalize.hpp>
 #include <cpd/utils.hpp>
@@ -190,7 +190,7 @@ private:
 /// Runs a registration with a default comparer.
 template <typename Transform>
 typename Transform::Result run(const Matrix& fixed, const Matrix& source) {
-    Runner<Transform, DirectComparer> runner;
+    Runner<Transform, DefaultComparer> runner;
     return runner.run(fixed, source);
 }
 }

--- a/scripts/travis-script.sh
+++ b/scripts/travis-script.sh
@@ -8,11 +8,12 @@ home=$(pwd)
 mkdir build
 cd build
 cmake .. \
-    -DWITH_TESTS=ON \
-    -DWITH_DOCS=ON \
     -DBUILD_SHARED_LIBS=ON \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=${home}/local
+    -DCMAKE_INSTALL_PREFIX=${home}/local \
+    -DWITH_DOCS=ON \
+    -DWITH_FGT=$CPD_WITH_FGT \
+    -DWITH_TESTS=ON
 make
 CTEST_OUTPUT_ON_FAIULRE=1 make test
 make install

--- a/src/comparer/direct.cpp
+++ b/src/comparer/direct.cpp
@@ -15,7 +15,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-#include "cpd/comparer.hpp"
+#include "cpd/comparer/direct.hpp"
 
 namespace cpd {
 
@@ -55,48 +55,5 @@ Probabilities DirectComparer::compute(const Matrix& fixed, const Matrix& moving,
     }
     l += cols * fixed.rows() * std::log(sigma2) / 2;
     return { p1, pt1, px, l, correspondence };
-}
-
-std::unique_ptr<fgt::Transform> FgtComparer::create_transform(
-    const Matrix& points, double bandwidth) const {
-    switch (m_method) {
-        case FgtMethod::DirectTree:
-            return std::unique_ptr<fgt::Transform>(
-                new fgt::DirectTree(points, bandwidth, m_epsilon));
-        case FgtMethod::Ifgt:
-            return std::unique_ptr<fgt::Transform>(
-                new fgt::Ifgt(points, bandwidth, m_epsilon));
-        case FgtMethod::Switched:
-            if (bandwidth > m_breakpoint) {
-                return std::unique_ptr<fgt::Transform>(
-                    new fgt::Ifgt(points, bandwidth, m_epsilon));
-            } else {
-                return std::unique_ptr<fgt::Transform>(
-                    new fgt::DirectTree(points, bandwidth, m_epsilon));
-            }
-    }
-    return std::unique_ptr<fgt::Transform>();
-}
-
-Probabilities FgtComparer::compute(const Matrix& fixed, const Matrix& moving,
-                                   double sigma2, double outliers) const {
-    double bandwidth = std::sqrt(2.0 * sigma2);
-    size_t cols = fixed.cols();
-    std::unique_ptr<fgt::Transform> transform =
-        create_transform(moving, bandwidth);
-    auto kt1 = transform->compute(fixed);
-    double ndi = outliers / (1.0 - outliers) * moving.rows() / fixed.rows() *
-                 std::pow(2.0 * M_PI * sigma2, 0.5 * cols);
-    Array denom_p = kt1.array() + ndi;
-    Vector pt1 = 1 - ndi / denom_p;
-    transform = create_transform(fixed, bandwidth);
-    Vector p1 = transform->compute(moving, 1 / denom_p);
-    Matrix px(moving.rows(), cols);
-    for (size_t i = 0; i < cols; ++i) {
-        px.col(i) = transform->compute(moving, fixed.col(i).array() / denom_p);
-    }
-    double l =
-        -denom_p.log().sum() + cols * fixed.rows() * std::log(sigma2) / 2;
-    return { p1, pt1, px, l };
 }
 }

--- a/src/comparer/fgt.cpp
+++ b/src/comparer/fgt.cpp
@@ -1,0 +1,64 @@
+// cpd - Coherent Point Drift
+// Copyright (C) 2016 Pete Gadomski <pete.gadomski@gmail.com>
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include "cpd/comparer/fgt.hpp"
+
+namespace cpd {
+
+std::unique_ptr<fgt::Transform> FgtComparer::create_transform(
+    const Matrix& points, double bandwidth) const {
+    switch (m_method) {
+        case FgtMethod::DirectTree:
+            return std::unique_ptr<fgt::Transform>(
+                new fgt::DirectTree(points, bandwidth, m_epsilon));
+        case FgtMethod::Ifgt:
+            return std::unique_ptr<fgt::Transform>(
+                new fgt::Ifgt(points, bandwidth, m_epsilon));
+        case FgtMethod::Switched:
+            if (bandwidth > m_breakpoint) {
+                return std::unique_ptr<fgt::Transform>(
+                    new fgt::Ifgt(points, bandwidth, m_epsilon));
+            } else {
+                return std::unique_ptr<fgt::Transform>(
+                    new fgt::DirectTree(points, bandwidth, m_epsilon));
+            }
+    }
+    return std::unique_ptr<fgt::Transform>();
+}
+
+Probabilities FgtComparer::compute(const Matrix& fixed, const Matrix& moving,
+                                   double sigma2, double outliers) const {
+    double bandwidth = std::sqrt(2.0 * sigma2);
+    size_t cols = fixed.cols();
+    std::unique_ptr<fgt::Transform> transform =
+        create_transform(moving, bandwidth);
+    auto kt1 = transform->compute(fixed);
+    double ndi = outliers / (1.0 - outliers) * moving.rows() / fixed.rows() *
+                 std::pow(2.0 * M_PI * sigma2, 0.5 * cols);
+    Array denom_p = kt1.array() + ndi;
+    Vector pt1 = 1 - ndi / denom_p;
+    transform = create_transform(fixed, bandwidth);
+    Vector p1 = transform->compute(moving, 1 / denom_p);
+    Matrix px(moving.rows(), cols);
+    for (size_t i = 0; i < cols; ++i) {
+        px.col(i) = transform->compute(moving, fixed.col(i).array() / denom_p);
+    }
+    double l =
+        -denom_p.log().sum() + cols * fixed.rows() * std::log(sigma2) / 2;
+    return { p1, pt1, px, l };
+}
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,8 +3,10 @@ configure_file(support.hpp.in "${CMAKE_CURRENT_BINARY_DIR}/support.hpp")
 find_package(Threads)
 
 function(cpd_test name)
+    set(src ${name}.cpp)
+    string(REPLACE "/" "-" name ${name})
     set(target ${name}-test)
-    add_executable(${target} ${name}.cpp "${GOOGLETEST_DIR}/src/gtest-all.cc" "${GOOGLETEST_DIR}/src/gtest_main.cc")
+    add_executable(${target} ${src} "${GOOGLETEST_DIR}/src/gtest-all.cc" "${GOOGLETEST_DIR}/src/gtest_main.cc")
     set_target_properties(${target} PROPERTIES OUTPUT_NAME ${name})
     add_test(NAME ${name} COMMAND ${target})
     target_link_libraries(${target} PRIVATE Library-C++)
@@ -15,6 +17,7 @@ function(cpd_test name)
         "${PROJECT_SOURCE_DIR}/include"
         "${PROJECT_SOURCE_DIR}/include/cpd/vendor"
         "${CMAKE_CURRENT_BINARY_DIR}"
+        "${CMAKE_CURRENT_SOURCE_DIR}"
         )
 
     if(CMAKE_USE_PTHREADS_INIT)
@@ -23,9 +26,13 @@ function(cpd_test name)
 endfunction()
 
 cpd_test(affinity_matrix)
-cpd_test(comparer)
+cpd_test(comparer/direct)
 cpd_test(nonrigid)
 cpd_test(normalize)
 cpd_test(rigid)
 cpd_test(utils)
 cpd_test(version)
+
+if(WITH_FGT)
+    cpd_test(comparer/fgt)
+endif()

--- a/test/comparer/common.hpp
+++ b/test/comparer/common.hpp
@@ -15,24 +15,14 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-#include "cpd/comparer.hpp"
-#include "support.hpp"
+#pragma once
+
+#include "cpd/probabilities.hpp"
 #include "gtest/gtest.h"
 
 namespace cpd {
 
-template <typename Comparer>
-class ComparerTest : public ::testing::Test {};
-
-typedef ::testing::Types<DirectComparer, FgtComparer> ComparerTypes;
-TYPED_TEST_CASE(ComparerTest, ComparerTypes);
-
-TYPED_TEST(ComparerTest, 2D) {
-    TypeParam computer;
-    auto fish = test_data_matrix("fish.csv");
-    auto fish_distorted = test_data_matrix("fish-distorted.csv");
-    Probabilities probabilities =
-        computer.compute(fish, fish_distorted, 1.0, 0.1);
+void check_fish_probabilities(const Probabilities& probabilities) {
     ASSERT_EQ(91, probabilities.p1.size());
     EXPECT_NEAR(0.6850, probabilities.p1(0), 1e-4);
     EXPECT_NEAR(1.0689, probabilities.p1(90), 1e-4);
@@ -46,24 +36,7 @@ TYPED_TEST(ComparerTest, 2D) {
     EXPECT_NEAR(-338.4930, probabilities.l, 1e-3);
 }
 
-TEST(DirectComparer, Correspondence) {
-    DirectComparer computer;
-    auto fish = test_data_matrix("fish.csv");
-    auto fish_distorted = test_data_matrix("fish-distorted.csv");
-    IndexVector correspondence =
-        test_data_matrix("fish-correspondence.csv").cast<Matrix::Index>();
-    Probabilities probabilities =
-        computer.compute(fish, fish_distorted, 1.0, 0.1);
-    EXPECT_EQ(correspondence.size(), probabilities.correspondence.size());
-    EXPECT_EQ(correspondence, probabilities.correspondence);
-}
-
-TYPED_TEST(ComparerTest, 3D) {
-    TypeParam computer;
-    auto face = test_data_matrix("face.csv");
-    auto face_distorted = test_data_matrix("face-distorted.csv");
-    Probabilities probabilities =
-        computer.compute(face, face_distorted, 1.0, 0.1);
+void check_face_probabilities(const Probabilities& probabilities) {
     ASSERT_EQ(392, probabilities.p1.size());
     EXPECT_NEAR(0.6171, probabilities.p1(0), 1e-4);
     EXPECT_NEAR(0.4869, probabilities.p1(391), 1e-4);

--- a/test/comparer/direct.cpp
+++ b/test/comparer/direct.cpp
@@ -1,0 +1,54 @@
+// cpd - Coherent Point Drift
+// Copyright (C) 2016 Pete Gadomski <pete.gadomski@gmail.com>
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include "cpd/comparer/direct.hpp"
+#include "comparer/common.hpp"
+#include "support.hpp"
+#include "gtest/gtest.h"
+
+namespace cpd {
+
+TEST(DirectComparer, 2D) {
+    DirectComparer comparer;
+    auto fish = test_data_matrix("fish.csv");
+    auto fish_distorted = test_data_matrix("fish-distorted.csv");
+    Probabilities probabilities =
+        comparer.compute(fish, fish_distorted, 1.0, 0.1);
+    check_fish_probabilities(probabilities);
+}
+
+TEST(DirectComparer, 3D) {
+    DirectComparer comparer;
+    auto face = test_data_matrix("face.csv");
+    auto face_distorted = test_data_matrix("face-distorted.csv");
+    Probabilities probabilities =
+        comparer.compute(face, face_distorted, 1.0, 0.1);
+    check_face_probabilities(probabilities);
+}
+
+TEST(DirectComparer, Correspondence) {
+    DirectComparer comparer;
+    auto fish = test_data_matrix("fish.csv");
+    auto fish_distorted = test_data_matrix("fish-distorted.csv");
+    IndexVector correspondence =
+        test_data_matrix("fish-correspondence.csv").cast<Matrix::Index>();
+    Probabilities probabilities =
+        comparer.compute(fish, fish_distorted, 1.0, 0.1);
+    EXPECT_EQ(correspondence.size(), probabilities.correspondence.size());
+    EXPECT_EQ(correspondence, probabilities.correspondence);
+}
+}

--- a/test/comparer/fgt.cpp
+++ b/test/comparer/fgt.cpp
@@ -1,0 +1,42 @@
+// cpd - Coherent Point Drift
+// Copyright (C) 2016 Pete Gadomski <pete.gadomski@gmail.com>
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include "cpd/comparer/fgt.hpp"
+#include "comparer/common.hpp"
+#include "support.hpp"
+#include "gtest/gtest.h"
+
+namespace cpd {
+
+TEST(FgtComparer, 2D) {
+    FgtComparer comparer;
+    auto fish = test_data_matrix("fish.csv");
+    auto fish_distorted = test_data_matrix("fish-distorted.csv");
+    Probabilities probabilities =
+        comparer.compute(fish, fish_distorted, 1.0, 0.1);
+    check_fish_probabilities(probabilities);
+}
+
+TEST(FgtComparer, 3D) {
+    FgtComparer comparer;
+    auto face = test_data_matrix("face.csv");
+    auto face_distorted = test_data_matrix("face-distorted.csv");
+    Probabilities probabilities =
+        comparer.compute(face, face_distorted, 1.0, 0.1);
+    check_face_probabilities(probabilities);
+}
+}

--- a/test/rigid.cpp
+++ b/test/rigid.cpp
@@ -17,7 +17,7 @@
 
 #include <Eigen/Geometry>
 
-#include "cpd/comparer.hpp"
+#include "cpd/comparer/default.hpp"
 #include "cpd/matrix.hpp"
 #include "cpd/rigid.hpp"
 #include "support.hpp"
@@ -66,7 +66,7 @@ public:
 
 TEST_F(Rigid2DTest, AllowScaling) {
     m_fish_transformed = test_data_matrix("fish-distorted.csv");
-    DirectComparer computer;
+    DefaultComparer computer;
     Probabilities probabilities =
         computer.compute(m_fish, m_fish_transformed, 1.0, 0.1);
     Rigid rigid;
@@ -77,7 +77,7 @@ TEST_F(Rigid2DTest, AllowScaling) {
 
 TEST_F(Rigid2DTest, NoScaling) {
     m_fish_transformed = test_data_matrix("fish-distorted.csv");
-    DirectComparer computer;
+    DefaultComparer computer;
     Probabilities probabilities =
         computer.compute(m_fish, m_fish_transformed, 1.0, 0.1);
     Rigid rigid;


### PR DESCRIPTION
We want this library to be as simple as possible to use, and since we can use it without libfgt, we should enable that possibility.

Fixes #78.