### PR TITLE
Revert to googletest's targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ option(WITH_TESTS "Build test suite" ON)
 if(WITH_TESTS)
     enable_testing()
     set(GOOGLETEST_DIR "${PROJECT_SOURCE_DIR}/vendor/googletest-release-1.8.0/googletest")
+    add_subdirectory(${GOOGLETEST_DIR})
     add_subdirectory(test)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,12 +6,11 @@ function(cpd_test name)
     set(src ${name}.cpp)
     string(REPLACE "/" "-" name ${name})
     set(target ${name}-test)
-    add_executable(${target} ${src} "${GOOGLETEST_DIR}/src/gtest-all.cc" "${GOOGLETEST_DIR}/src/gtest_main.cc")
+    add_executable(${target} ${src})
     set_target_properties(${target} PROPERTIES OUTPUT_NAME ${name})
     add_test(NAME ${name} COMMAND ${target})
-    target_link_libraries(${target} PRIVATE Library-C++)
+    target_link_libraries(${target} PRIVATE Library-C++ gtest_main)
     target_include_directories(${target} PRIVATE
-        "${GOOGLETEST_DIR}"
         "${GOOGLETEST_DIR}/include"
         "${PROJECT_SOURCE_DIR}/src"
         "${PROJECT_SOURCE_DIR}/include"

--- a/vendor/googletest-release-1.8.0/googletest/CMakeLists.txt
+++ b/vendor/googletest-release-1.8.0/googletest/CMakeLists.txt
@@ -47,6 +47,10 @@ endif()
 project(gtest CXX C)
 cmake_minimum_required(VERSION 2.6.2)
 
+if(POLICY CMP0042) # MACOSX_RPATH
+    cmake_policy(SET CMP0042 NEW)
+endif()
+
 if (COMMAND set_up_hermetic_build)
   set_up_hermetic_build()
 endif()
@@ -65,9 +69,6 @@ config_compiler_and_linker()  # Defined in internal_utils.cmake.
 include_directories(
   ${gtest_SOURCE_DIR}/include
   ${gtest_SOURCE_DIR})
-
-# Where Google Test's libraries can be found.
-link_directories(${gtest_BINARY_DIR}/src)
 
 # Summary of tuple support for Microsoft Visual Studio:
 # Compiler    version(MS)  version(cmake)  Support


### PR DESCRIPTION
It takes a bit of modification to the googletest cmake file, but we can
just build a googletest target then link tests against that. This
improves compile time.

Fixes #84.