### PR TITLE
Better allocation error when creating affinity matrix

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,3 +8,6 @@ target_link_libraries(cpd-rigid PRIVATE Cpd::Library-C++ Cpd::Jsoncpp)
 find_package(Cpd REQUIRED)
 add_executable(cpd-version version.cpp)
 target_link_libraries(cpd-version PRIVATE Cpd::Library-C++)
+
+add_executable(cpd-random random.cpp)
+target_link_libraries(cpd-random PRIVATE Cpd::Library-C++)

--- a/examples/random.cpp
+++ b/examples/random.cpp
@@ -1,0 +1,34 @@
+/// Create two random datasets and run cpd on them.
+///
+/// This is mostly to test for behavior when running overly-large data through
+/// nonrigid (#104).
+
+#include <iostream>
+#include <string>
+
+#include <cpd/nonrigid.hpp>
+#include <cpd/rigid.hpp>
+
+int main(int argc, char** argv) {
+    if (argc != 4) {
+        std::cout << "Invalid usage: cpd-random <method> <rows> <cols>"
+                  << std::endl;
+        return 1;
+    }
+    std::string method = argv[1];
+    size_t rows = std::stoi(argv[2]);
+    size_t cols = std::stoi(argv[3]);
+    cpd::Matrix fixed = cpd::Matrix::Random(rows, cols);
+    cpd::Matrix moving = cpd::Matrix::Random(rows, cols);
+
+    if (method == "rigid") {
+        cpd::rigid(fixed, moving);
+    } else if (method == "nonrigid") {
+        cpd::nonrigid(fixed, moving);
+    } else {
+        std::cout << "Invalid method: " << method << std::endl;
+        return 1;
+    }
+    std::cout << "Registration completed OK" << std::endl;
+    return 0;
+}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -76,7 +76,15 @@ Matrix affinity(const Matrix& x, const Matrix& y, double beta) {
     double k = -2.0 * beta * beta;
     size_t x_rows = x.rows();
     size_t y_rows = y.rows();
-    Matrix g(x_rows, y_rows);
+    Matrix g;
+    try {
+        g = Matrix(x_rows, y_rows);
+    } catch (const std::bad_alloc& err) {
+        std::stringstream msg;
+        msg << "Unable to allocate " << x_rows << " by " << y_rows
+            << " affinity matrix, try again with fewer points";
+        throw std::runtime_error(msg.str());
+    }
     for (size_t i = 0; i < y_rows; ++i) {
         g.col(i) = ((x.array() - y.row(i).replicate(x_rows, 1).array())
                         .pow(2)


### PR DESCRIPTION
This patch both improves reporting when an allocation error occurs during affinity matrix creation, and adds a new example executable (`random`) to test large allocations.