### PR TITLE
Add a matrix method for rigid and affine results

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ configure_file(src/version.cpp.in "${PROJECT_BINARY_DIR}/src/version.cpp")
 set(library-src
     src/affine.cpp
     src/gauss_transform.cpp
+    src/matrix.cpp
     src/nonrigid.cpp
     src/normalization.cpp
     src/rigid.cpp

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -19,3 +19,6 @@ target_link_libraries(cpd-version PRIVATE Cpd::Library-C++)
 
 add_executable(cpd-random random.cpp)
 target_link_libraries(cpd-random PRIVATE Cpd::Library-C++)
+
+add_executable(cpd-transform transform.cpp)
+target_link_libraries(cpd-transform PRIVATE Cpd::Library-C++)

--- a/examples/transform.cpp
+++ b/examples/transform.cpp
@@ -1,0 +1,52 @@
+// cpd - Coherent Point Drift
+// Copyright (C) 2017 Pete Gadomski <pete.gadomski@gmail.com>
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include <cpd/affine.hpp>
+#include <cpd/rigid.hpp>
+#include <fstream>
+#include <iostream>
+
+int main(int argc, char** argv) {
+    if (argc == 1) {
+        std::cerr << "ERROR: invalid usage" << std::endl;
+        return 1;
+    }
+    cpd::Matrix fixed = cpd::matrix_from_path(argv[2]);
+    cpd::Matrix moving = cpd::matrix_from_path(argv[3]);
+    if (std::strcmp(argv[1], "rigid") == 0) {
+        cpd::Rigid rigid;
+        rigid.scale(true);
+        cpd::RigidResult result = rigid.run(fixed, moving);
+        cpd::Matrix transform = result.matrix();
+        std::cout << transform << std::endl;
+    } else if (std::strcmp(argv[1], "affine") == 0) {
+        cpd::AffineResult result = cpd::affine(fixed, moving);
+        cpd::Matrix transform = result.matrix();
+        std::cout << transform << std::endl;
+    } else if (std::strcmp(argv[1], "apply") == 0) {
+        cpd::Matrix transform = cpd::matrix_from_path(argv[2]);
+        cpd::Matrix points = cpd::matrix_from_path(argv[3]);
+        points = cpd::apply_transformation_matrix(points, transform);
+        std::ofstream outfile(argv[4]);
+        outfile << points << std::endl;
+        outfile.close();
+    } else {
+        std::cerr << "ERROR: invalid method '" << argv[1] << "'" << std::endl;
+        return 1;
+    }
+    return 0;
+}

--- a/include/cpd/affine.hpp
+++ b/include/cpd/affine.hpp
@@ -33,6 +33,9 @@ struct AffineResult : public Result {
     /// The translation vector.
     Vector translation;
 
+    /// Returns the transform and the translation as one matrix.
+    Matrix matrix() const;
+
     /// Denormalize this result.
     void denormalize(const Normalization& normalization);
 };

--- a/include/cpd/rigid.hpp
+++ b/include/cpd/rigid.hpp
@@ -39,6 +39,10 @@ struct RigidResult : public Result {
     /// The scaling component of the transformation.
     double scale;
 
+    /// Returns a single matrix that contains all the transformation
+    /// information.
+    Matrix matrix() const;
+
     void denormalize(const Normalization& normalization);
 };
 

--- a/src/affine.cpp
+++ b/src/affine.cpp
@@ -48,6 +48,20 @@ AffineResult Affine::compute_one(const Matrix& fixed, const Matrix& moving,
     return result;
 }
 
+Matrix AffineResult::matrix() const {
+    Matrix::Index rows = transform.rows() + 1;
+    Matrix::Index cols = transform.cols() + 1;
+    Matrix matrix = Matrix::Zero(rows, cols);
+    for (Matrix::Index row = 0; row < transform.rows(); ++row) {
+        for (Matrix::Index col = 0; col < transform.cols(); ++col) {
+            matrix(row, col) = transform(row, col);
+        }
+        matrix(row, cols - 1) = translation(row);
+    }
+    matrix(rows - 1, cols - 1) = 1;
+    return matrix;
+}
+
 void AffineResult::denormalize(const Normalization& normalization) {
     Result::denormalize(normalization);
     translation = normalization.fixed_scale * translation + normalization.fixed_mean -

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -15,30 +15,16 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-/// \file
-///
-/// Basic typedefs for our flavors of Eigen matrices.
-
-#pragma once
-
-#include <Eigen/Dense>
+#include <cpd/matrix.hpp>
 
 namespace cpd {
 
-/// Our base matrix class.
-typedef Eigen::MatrixXd Matrix;
-
-/// Typedef for our specific type of vector.
-typedef Eigen::VectorXd Vector;
-
-/// Typedef for an index vector, used to index other matrices.
-typedef Eigen::Matrix<Matrix::Index, Eigen::Dynamic, 1> IndexVector;
-
-/// Typedef for our specific type of array.
-typedef Eigen::ArrayXd Array;
-
-/// Apply a transformation matrix to a set of points.
-///
-/// The transformation matrix should be one column wider than the point matrix.
-Matrix apply_transformation_matrix(Matrix points, const Matrix& transform);
+Matrix apply_transformation_matrix(Matrix points, const Matrix& transform) {
+    Matrix::Index rows = points.rows();
+    Matrix::Index cols = points.cols() + 1;
+    points.conservativeResize(rows, cols);
+    points.col(cols - 1) = Vector::Ones(rows);
+    Matrix transformed_points = points * transform.transpose();
+    return transformed_points.leftCols(cols - 1);
+}
 } // namespace cpd

--- a/src/rigid.cpp
+++ b/src/rigid.cpp
@@ -75,6 +75,20 @@ RigidResult rigid(const Matrix& fixed, const Matrix& moving) {
     return rigid.run(fixed, moving);
 }
 
+Matrix RigidResult::matrix() const {
+    Matrix::Index rows = rotation.rows() + 1;
+    Matrix::Index cols = rotation.cols() + 1;
+    Matrix matrix = Matrix::Zero(rows, cols);
+    for (Matrix::Index row = 0; row < rotation.rows(); ++row) {
+        for (Matrix::Index col = 0; col < rotation.cols(); ++col) {
+            matrix(row, col) = rotation(row, col) * scale;
+        }
+        matrix(row, cols - 1) = translation(row);
+    }
+    matrix(rows - 1, cols - 1) = 1;
+    return matrix;
+}
+
 void RigidResult::denormalize(const Normalization& normalization) {
     Result::denormalize(normalization);
     scale = scale * normalization.fixed_scale / normalization.moving_scale;

--- a/tests/affine.cpp
+++ b/tests/affine.cpp
@@ -58,4 +58,13 @@ TEST(Affine, Linked) {
     affine.linked(false);
     EXPECT_FALSE(affine.linked());
 }
+
+TEST_F(FishTest, AffineMatrix) {
+    AffineResult result = affine(m_fish_distorted, m_fish);
+    Matrix transform = result.matrix();
+    ASSERT_EQ(transform.rows(), 3);
+    ASSERT_EQ(transform.cols(), 3);
+    Matrix fish = apply_transformation_matrix(m_fish, transform);
+    EXPECT_TRUE(result.points.isApprox(fish, 1e-4));
+}
 } // namespace cpd

--- a/tests/rigid.cpp
+++ b/tests/rigid.cpp
@@ -61,4 +61,13 @@ TEST(Rigid, Linked) {
     rigid.scale(false);
     EXPECT_TRUE(rigid.linked());
 }
+
+TEST_F(FishTest, OneMatrix) {
+    RigidResult result = rigid(m_fish_distorted, m_fish);
+    Matrix transform = result.matrix();
+    ASSERT_EQ(transform.rows(), 3);
+    ASSERT_EQ(transform.cols(), 3);
+    Matrix fish = apply_transformation_matrix(m_fish, transform);
+    EXPECT_TRUE(result.points.isApprox(fish, 1e-4));
+}
 } // namespace cpd


### PR DESCRIPTION
This matrix can be used to apply a rigid and affine transformation in one step. This patch also adds a convenience method, `apply_transformation_matrix`.