### PR TITLE
Add unlinked normalization

### DIFF
--- a/include/cpd/affine.hpp
+++ b/include/cpd/affine.hpp
@@ -40,10 +40,25 @@ struct AffineResult : public Result {
 /// Affine coherent point drift.
 class Affine : public Transform<AffineResult> {
 public:
+    Affine()
+      : Transform()
+      , m_linked(DEFAULT_LINKED) {}
+
     /// Computes one iteration of the affine transformation.
     AffineResult compute_one(const Matrix& fixed, const Matrix& moving,
                              const Probabilities& probabilities,
                              double sigma2) const;
+
+    /// Sets whether the scalings of the two datasets are linked.
+    Affine& linked(bool linked) {
+        m_linked = linked;
+        return *this;
+    }
+
+    virtual bool linked() const { return m_linked; }
+
+private:
+    bool m_linked;
 };
 
 /// Runs a affine registration on two matrices.

--- a/include/cpd/nonrigid.hpp
+++ b/include/cpd/nonrigid.hpp
@@ -39,7 +39,8 @@ public:
     Nonrigid()
       : Transform()
       , m_lambda(DEFAULT_LAMBDA)
-      , m_beta(DEFAULT_BETA) {}
+      , m_beta(DEFAULT_BETA)
+      , m_linked(DEFAULT_LINKED) {}
 
     /// Initialize this transform for the provided matrices.
     void init(const Matrix& fixed, const Matrix& moving);
@@ -64,11 +65,20 @@ public:
                                const Probabilities& probabilities,
                                double sigma2) const;
 
+    /// Sets whether the scalings of the two datasets are linked.
+    Nonrigid& linked(bool linked) {
+        m_linked = linked;
+        return *this;
+    }
+
+    virtual bool linked() const { return m_linked; }
+
 private:
     Matrix m_g;
     Matrix m_w;
     double m_lambda;
     double m_beta;
+    bool m_linked;
 };
 
 /// Runs a nonrigid registration on two matrices.

--- a/include/cpd/normalization.hpp
+++ b/include/cpd/normalization.hpp
@@ -32,14 +32,24 @@ struct Normalization {
     Vector fixed_mean;
     /// The fixed points.
     Matrix fixed;
+    /// The scaling factor for the fixed points.
+    double fixed_scale;
     /// The average of the moving points, that was subtracted from those data.
     Vector moving_mean;
     /// The moving points.
     Matrix moving;
-    /// The scaling factor for the points.
-    double scale;
+    /// The scaling factor for the moving points.
+    double moving_scale;
 
     /// Creates a new normalization for the provided matrices.
-    Normalization(const Matrix& fixed, const Matrix& moving);
+    ///
+    /// If `linked = true`, apply the same scaling to both sets of points. This
+    /// is recommended if you are working with data that should not be scaled,
+    /// e.g. LiDAR data. If `linked = false`, each point set is scaled
+    /// seperately.
+    ///
+    /// Myronenko's original implementation only had `linked = false` logic.
+    Normalization(const Matrix& fixed, const Matrix& moving,
+                  bool linked = true);
 };
 } // namespace cpd

--- a/include/cpd/rigid.hpp
+++ b/include/cpd/rigid.hpp
@@ -28,7 +28,7 @@ namespace cpd {
 /// Should rigid registrations allow reflections by default?
 const bool DEFAULT_REFLECTIONS = false;
 /// Should rigid registrations scale the data by default?
-const bool DEFAULT_SCALE = false;
+const bool DEFAULT_SCALE = !DEFAULT_LINKED;
 
 /// The result of a rigid coherent point drift run.
 struct RigidResult : public Result {
@@ -68,6 +68,8 @@ public:
     RigidResult compute_one(const Matrix& fixed, const Matrix& moving,
                             const Probabilities& probabilities,
                             double sigma2) const;
+
+    virtual bool linked() const { return !m_scale; }
 
 private:
     bool m_reflections;

--- a/include/cpd/transform.hpp
+++ b/include/cpd/transform.hpp
@@ -45,6 +45,8 @@ const double DEFAULT_TOLERANCE = 1e-5;
 const double DEFAULT_SIGMA2 = 0.0;
 /// Whether correspondence vector should be computed by default.
 const bool DEFAULT_CORRESPONDENCE = false;
+/// Are the scalings of the two datasets linked by default?
+const bool DEFAULT_LINKED = true;
 
 /// The result of a generic transform run.
 struct Result {
@@ -127,7 +129,7 @@ public:
     /// Runs this transform for the provided matrices.
     Result run(Matrix fixed, Matrix moving) {
         auto tic = std::chrono::high_resolution_clock::now();
-        Normalization normalization(fixed, moving);
+        Normalization normalization(fixed, moving, linked());
         if (m_normalize) {
             fixed = normalization.fixed;
             moving = normalization.moving;
@@ -140,7 +142,7 @@ public:
         if (m_sigma2 == 0.0) {
             result.sigma2 = cpd::default_sigma2(fixed, moving);
         } else if (m_normalize) {
-            result.sigma2 = m_sigma2 / normalization.scale;
+            result.sigma2 = m_sigma2 / normalization.fixed_scale;
         } else {
             result.sigma2 = m_sigma2;
         }
@@ -195,6 +197,11 @@ public:
     virtual Result compute_one(const Matrix& fixed, const Matrix& moving,
                                const Probabilities& probabilities,
                                double sigma2) const = 0;
+
+    /// Returns true if the normalization should be linked.
+    ///
+    /// No effect if no normalization is applied.
+    virtual bool linked() const = 0;
 
 private:
     bool m_correspondence;

--- a/src/affine.cpp
+++ b/src/affine.cpp
@@ -50,8 +50,9 @@ AffineResult Affine::compute_one(const Matrix& fixed, const Matrix& moving,
 
 void AffineResult::denormalize(const Normalization& normalization) {
     Result::denormalize(normalization);
-    translation = normalization.scale * translation + normalization.fixed_mean -
+    translation = normalization.fixed_scale * translation + normalization.fixed_mean -
                   transform * normalization.moving_mean;
+    transform = transform * normalization.fixed_scale / normalization.moving_scale;
 }
 
 AffineResult affine(const Matrix& fixed, const Matrix& moving) {

--- a/src/normalization.cpp
+++ b/src/normalization.cpp
@@ -19,14 +19,19 @@
 
 namespace cpd {
 
-Normalization::Normalization(const Matrix& f, const Matrix& m)
+Normalization::Normalization(const Matrix& f, const Matrix& m, bool linked)
   : fixed_mean(f.colwise().mean())
   , fixed(f - fixed_mean.transpose().replicate(f.rows(), 1))
+  , fixed_scale(std::sqrt(fixed.array().pow(2).sum() / fixed.rows()))
   , moving_mean(m.colwise().mean())
   , moving(m - moving_mean.transpose().replicate(m.rows(), 1))
-  , scale(std::max(std::sqrt(fixed.array().pow(2).sum() / fixed.rows()),
-                   std::sqrt(moving.array().pow(2).sum() / moving.rows()))) {
-    fixed /= scale;
-    moving /= scale;
+  , moving_scale(std::sqrt(moving.array().pow(2).sum() / moving.rows())) {
+    if (linked) {
+        double scale = std::max(fixed_scale, moving_scale);
+        fixed_scale = scale;
+        moving_scale = scale;
+    }
+    fixed /= fixed_scale;
+    moving /= moving_scale;
 }
 } // namespace cpd

--- a/src/rigid.cpp
+++ b/src/rigid.cpp
@@ -77,7 +77,8 @@ RigidResult rigid(const Matrix& fixed, const Matrix& moving) {
 
 void RigidResult::denormalize(const Normalization& normalization) {
     Result::denormalize(normalization);
-    translation = normalization.scale * translation + normalization.fixed_mean -
+    scale = scale * normalization.fixed_scale / normalization.moving_scale;
+    translation = normalization.fixed_scale * translation + normalization.fixed_mean -
                   scale * rotation * normalization.moving_mean;
 }
 } // namespace cpd

--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -20,7 +20,7 @@
 namespace cpd {
 
 void Result::denormalize(const Normalization& normalization) {
-    points = points * normalization.scale +
+    points = points * normalization.fixed_scale +
              normalization.fixed_mean.transpose().replicate(points.rows(), 1);
 }
 } // namespace cpd

--- a/tests/affine.cpp
+++ b/tests/affine.cpp
@@ -50,4 +50,12 @@ TEST_F(FaceTest, Affine) {
     EXPECT_TRUE(result.transform.isApprox(transform.transpose(), 1e-4));
     EXPECT_TRUE(result.translation.isApprox(translation, 1e-4));
 }
+
+TEST(Affine, Linked) {
+    Affine affine;
+    affine.linked(true);
+    EXPECT_TRUE(affine.linked());
+    affine.linked(false);
+    EXPECT_FALSE(affine.linked());
+}
 } // namespace cpd

--- a/tests/nonrigid.cpp
+++ b/tests/nonrigid.cpp
@@ -35,4 +35,12 @@ TEST_F(FaceTest, Works) {
     EXPECT_TRUE(result.points.row(0).isApprox(m_face.row(0), 0.01));
     EXPECT_TRUE(result.points.row(391).isApprox(m_face.row(391), 0.5));
 }
+
+TEST(Nonrigid, Linked) {
+    Nonrigid nonrigid;
+    nonrigid.linked(true);
+    EXPECT_TRUE(nonrigid.linked());
+    nonrigid.linked(false);
+    EXPECT_FALSE(nonrigid.linked());
+}
 } // namespace cpd

--- a/tests/normalization.cpp
+++ b/tests/normalization.cpp
@@ -25,9 +25,15 @@ TEST_F(FishTest, CanBeRetrieved) {
     Normalization normalization(m_fish, m_fish);
     ASSERT_EQ(m_fish.rows(), normalization.fixed.rows());
     EXPECT_TRUE(
-        m_fish.isApprox(normalization.fixed * normalization.scale +
+        m_fish.isApprox(normalization.fixed * normalization.fixed_scale +
                             normalization.fixed_mean.transpose().replicate(
                                 normalization.fixed.rows(), 1),
                         1e-4));
+}
+
+TEST_F(FishTest, Unlinked) {
+    Normalization normalization(m_fish, m_fish * 2, false);
+    EXPECT_NEAR(normalization.fixed_scale, normalization.moving_scale / 2.0,
+                1e-4);
 }
 } // namespace cpd

--- a/tests/rigid.cpp
+++ b/tests/rigid.cpp
@@ -53,4 +53,12 @@ TEST_F(FishTest, Scale) {
     RigidResult result = rigid.run(m_fish_distorted, m_fish);
     EXPECT_NEAR(10.0, result.scale, 0.1);
 }
+
+TEST(Rigid, Linked) {
+    Rigid rigid;
+    rigid.scale(true);
+    EXPECT_FALSE(rigid.linked());
+    rigid.scale(false);
+    EXPECT_TRUE(rigid.linked());
+}
 } // namespace cpd


### PR DESCRIPTION
Unlinked normalization is when each point set has its own scaling
factor. Unlinked is good for things like photogrammetry, where the
points will most likely need to be scaled. Linked is good for LiDAR,
where you (usually) don't want to scale the points.

Fixed #112.