### PR TITLE
use math defines and include cmath

### DIFF
--- a/src/gauss_transform_fgt.cpp
+++ b/src/gauss_transform_fgt.cpp
@@ -15,7 +15,10 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#define _USE_MATH_DEFINES
+
 #include <cpd/gauss_transform_fgt.hpp>
+#include <cmath>
 
 namespace cpd {
 std::unique_ptr<GaussTransform> GaussTransform::make_default() {


### PR DESCRIPTION
This commit adds the "use math defines" statement and includes cmath. Otherwise gauss_transform_fgt.cpp will not compile when using fgt, because M_PI is undefined