### PR TITLE
Add the ability to use callbacks.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -20,5 +20,8 @@ target_link_libraries(cpd-version PRIVATE Cpd::Library-C++)
 add_executable(cpd-random random.cpp)
 target_link_libraries(cpd-random PRIVATE Cpd::Library-C++)
 
+add_executable(cpd-callback callback.cpp)
+target_link_libraries(cpd-callback PRIVATE Cpd::Library-C++)
+
 add_executable(cpd-transform transform.cpp)
 target_link_libraries(cpd-transform PRIVATE Cpd::Library-C++)

--- a/examples/callback.cpp
+++ b/examples/callback.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+#include <string>
+
+#include <cpd/nonrigid.hpp>
+#include <cpd/rigid.hpp>
+
+void RigidCallback(const cpd::Result &r) {
+  std::cout << r.points << std::endl << std::endl;
+}
+
+void NonrigidCallback(const cpd::NonrigidResult &r) {
+  std::cout << r.points << std::endl << std::endl;
+}
+
+int main(int argc, char** argv) {
+    if (argc != 4) {
+        std::cout << "Invalid usage: cpd-random <method> <rows> <cols>"
+                  << std::endl;
+        return 1;
+    }
+    std::string method = argv[1];
+    size_t rows = std::stoi(argv[2]);
+    size_t cols = std::stoi(argv[3]);
+    cpd::Matrix fixed = cpd::Matrix::Random(rows, cols);
+    cpd::Matrix moving = cpd::Matrix::Random(rows, cols);
+
+    if (method == "rigid") {
+        cpd::Rigid rigid;
+        auto *cb = RigidCallback;
+        rigid.add_callback(cb);
+        auto rigid_result = rigid.run(fixed, moving);
+    } else if (method == "nonrigid") {
+        cpd::Nonrigid nonrigid;
+        auto *cb = NonrigidCallback;
+        nonrigid.add_callback(cb);
+        auto nonrigid_result = nonrigid.run(fixed, moving);
+    } else {
+        std::cout << "Invalid method: " << method << std::endl;
+        return 1;
+    }
+    std::cout << "Registration completed OK" << std::endl;
+    return 0;
+}
+
+


### PR DESCRIPTION
This pull request allows the user to add callbacks, which are called on each iteration of the CPD algorithm.  The callbacks are stored as a vector of `std::function` specializations, such that function pointers, pointers to methods, and lambda functions may all be passed as callbacks.  A simple example is also added.

This PR is a first step in addressing [this issue](https://github.com/gadomski/cpd/issues/110).