### PR TITLE
Add static/dynamic logic to jsoncpp cmake

### DIFF
--- a/components/jsoncpp/CMakeLists.txt
+++ b/components/jsoncpp/CMakeLists.txt
@@ -1,5 +1,18 @@
 add_library(Jsoncpp src/jsoncpp.cpp)
-target_link_libraries(Jsoncpp PUBLIC Library-C++ jsoncpp_lib)
+if(${BUILD_SHARED_LIBS})
+	if(NOT TARGET jsoncpp_lib)
+		message(FATAL_ERROR "Target jsoncpp_lib is not defined, but is required because cpd is building shared libs. Make sure `BUILD_SHARED_LIBS` is enabled in your jsoncpp installation.")
+	else()
+		set(jsoncpp_lib jsoncpp_lib)
+	endif()
+else()
+	if(NOT TARGET jsoncpp_lib_static)
+		message(FATAL_ERROR "Target jsoncpp_lib_static is not defined, but is required because cpd is building static libs. Make sure `BUILD_STATIC_LIBS` is enabled in your jsoncpp installation.")
+	else()
+		set(jsoncpp_lib jsoncpp_lib_static)
+	endif()
+endif()
+target_link_libraries(Jsoncpp PUBLIC Library-C++ ${jsoncpp_lib})
 set_target_properties(Jsoncpp PROPERTIES
     OUTPUT_NAME cpd-jsoncpp
     VERSION ${CPD_VERSION}


### PR DESCRIPTION
If we're building cpd shared, find jsoncpp shared, and vice versa. Adds
sensible fatal error messages to point the user in the correct
direction.

Fixes #133.