### PR TITLE
Fix correspondences

### DIFF
--- a/include/cpd/transform.hpp
+++ b/include/cpd/transform.hpp
@@ -183,8 +183,9 @@ public:
             result.denormalize(normalization);
         }
         if (m_correspondence) {
-            Probabilities probabilities = m_gauss_transform->compute(
-                fixed, result.points, m_sigma2, m_outliers);
+            GaussTransformDirect direct;
+            Probabilities probabilities = direct.compute(
+                fixed, result.points, result.sigma2, m_outliers);
             result.correspondence = probabilities.correspondence;
             assert(result.correspondence.rows() > 0);
         }

--- a/tests/affine.cpp
+++ b/tests/affine.cpp
@@ -67,4 +67,11 @@ TEST_F(FishTest, AffineMatrix) {
     Matrix fish = apply_transformation_matrix(m_fish, transform);
     EXPECT_TRUE(result.points.isApprox(fish, 1e-4));
 }
+
+TEST_F(FishTest, Correspondences) {
+    Affine affine;
+    affine.correspondence(true);
+    AffineResult result = affine.run(m_fish_distorted, m_fish);
+    EXPECT_TRUE((result.correspondence.array() > 0).any());
+}
 } // namespace cpd

--- a/tests/nonrigid.cpp
+++ b/tests/nonrigid.cpp
@@ -43,4 +43,11 @@ TEST(Nonrigid, Linked) {
     nonrigid.linked(false);
     EXPECT_FALSE(nonrigid.linked());
 }
+
+TEST_F(FishTest, Correspondences) {
+    Nonrigid nonrigid;
+    nonrigid.correspondence(true);
+    NonrigidResult result = nonrigid.run(m_fish_distorted, m_fish);
+    EXPECT_TRUE((result.correspondence.array() > 0).any());
+}
 } // namespace cpd

--- a/tests/rigid.cpp
+++ b/tests/rigid.cpp
@@ -73,4 +73,11 @@ TEST_F(FishTest, OneMatrix) {
     Matrix fish = apply_transformation_matrix(m_fish, transform);
     EXPECT_TRUE(result.points.isApprox(fish, 1e-4));
 }
+
+TEST_F(FishTest, Correspondences) {
+    Rigid rigid;
+    rigid.correspondence(true);
+    RigidResult result = rigid.run(m_fish_distorted, m_fish);
+    EXPECT_TRUE((result.correspondence.array() > 0).any());
+}
 } // namespace cpd


### PR DESCRIPTION
There were two problems:
1. By using the original sigma2 value, all correspondences would be `0`.
2. If the transform's Gauss transformer was non direct, the correspondences wouldn't be calculated.

This patch fixes both, and adds tests.