### PR TITLE
sqrt() transform missing on the L2 norm.

### DIFF
--- a/src/gauss_transform.cpp
+++ b/src/gauss_transform.cpp
@@ -41,6 +41,7 @@ Probabilities GaussTransformDirect::compute(const Matrix& fixed,
         double sp = 0;
         for (Matrix::Index j = 0; j < moving.rows(); ++j) {
             double razn = (fixed.row(i) - moving.row(j)).array().pow(2).sum();
+            razn = std::sqrt(razn);
             p(j) = std::exp(razn / ksig);
             sp += p(j);
         }


### PR DESCRIPTION
If the square root transform is not performed the correspondance index will be wrong 
because it will lead to overestimate of one to many mapping between fixed and moving.