### PR TITLE
set FGT linkage to PRIVATE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,8 @@ target_include_directories(Library-C++
     ${EIGEN3_INCLUDE_DIR}
     )
 if(WITH_FGT)
-    target_link_libraries(Library-C++ PUBLIC Fgt::Library-C++)
-    target_compile_definitions(Library-C++ PUBLIC CPD_WITH_FGT)
+    target_link_libraries(Library-C++ PRIVATE Fgt::Library-C++)
+    target_compile_definitions(Library-C++ PRIVATE CPD_WITH_FGT)
 endif()
 
 option(WITH_STRICT_WARNINGS "Build with stricter warnings" ON)


### PR DESCRIPTION
I'm doing some @conda-forge packaging of CPD for PDAL and I'm getting the following error 

```
  The link interface of target "Cpd::Library-C++" contains:

    Fgt::Library-C++

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```

Was there any specific reason the FGT linkage is `PUBLIC` instead of `PRIVATE` [here](https://github.com/gadomski/cpd/blob/main/CMakeLists.txt#L65)? If it is PUBLIC for a reason, the Cpd-targets.cmake file is going to need to be updated to do a find_package(Fgt). 

